### PR TITLE
Rename field to match PokéAPI json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>skaro.pokeapi</groupId>
 	<artifactId>pokeapi-reactor</artifactId>
-	<version>1.0.2</version>
+	<version>1.0.3</version>
 	<name>pokeapi-reactor</name>
 	<description>Non-blocking, reactive API client for PokeAPI</description>
 	<properties>

--- a/src/main/java/skaro/pokeapi/resource/pokemon/PokemonMove.java
+++ b/src/main/java/skaro/pokeapi/resource/pokemon/PokemonMove.java
@@ -7,14 +7,14 @@ import skaro.pokeapi.resource.move.Move;
 
 public class PokemonMove {
 
-	private NamedApiResource<Move> moves;
+	private NamedApiResource<Move> move;
 	private List<PokemonMoveVersion> versionGroupDetails;
 	
-	public NamedApiResource<Move> getMoves() {
-		return moves;
+	public NamedApiResource<Move> getMove() {
+		return move;
 	}
-	public void setMoves(NamedApiResource<Move> moves) {
-		this.moves = moves;
+	public void setMove(NamedApiResource<Move> move) {
+		this.move = move;
 	}
 	public List<PokemonMoveVersion> getVersionGroupDetails() {
 		return versionGroupDetails;


### PR DESCRIPTION
The fields 'moves' inside the list of moves of a Pokémon becomes null, because it does not match the original json. In the json from PokéAPI this fields is called 'move' rather than 'moves'. This fixes the issue.
(Do I need to increase the version number by the way?)