### PR TITLE
Make maxBytesToBuffer configurable via application.properties/.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ You can (must) configure the location of the PokeAPI instance you want to use. A
 skaro.pokeapi.base-uri=https://pokeapi.co/api/v2/ #or the url of your own instance
 ```
 
+You may also configure the max buffer size for the WebClient, which is used to fetch resources from PokeAPI.
+Its default value is 565000 bytes, while the API request for "/pokemon/mew" can grow over the time, you may want to increase it yourself to a higher value.
+To achieve this, add the following property to your `application.properties`:
+```
+skaro.pokeapi.max-buffer-size=565000
+```
+
 #### Application Context
 Import one of pokeapi-reactor's configurations as well as specify your own [reactor.netty.http.client.HttpClient](https://projectreactor.io/docs/netty/release/api/reactor/netty/http/client/HttpClient.html) bean. Two configurations are available: caching and non-caching. Below is an example of a caching configuration which uses a flexible `HttpClient` tuned for high parallel throughput.
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>skaro.pokeapi</groupId>
 	<artifactId>pokeapi-reactor</artifactId>
-	<version>1.0.5</version>
+	<version>1.0.6</version>
 	<name>pokeapi-reactor</name>
 	<description>Non-blocking, reactive API client for PokeAPI</description>
 	<properties>

--- a/src/main/java/skaro/pokeapi/PokeApiConfigurationProperties.java
+++ b/src/main/java/skaro/pokeapi/PokeApiConfigurationProperties.java
@@ -8,7 +8,7 @@ public class PokeApiConfigurationProperties {
 
 	@NotNull
 	private URI baseUri;
-	private int maxBytesToBuffer = 550_000;
+	private int maxBytesToBuffer = 565_000;
 
 	public URI getBaseUri() {
 		return baseUri;

--- a/src/main/java/skaro/pokeapi/PokeApiConfigurationProperties.java
+++ b/src/main/java/skaro/pokeapi/PokeApiConfigurationProperties.java
@@ -8,6 +8,7 @@ public class PokeApiConfigurationProperties {
 
 	@NotNull
 	private URI baseUri;
+	private int maxBytesToBuffer = 550_000;
 
 	public URI getBaseUri() {
 		return baseUri;
@@ -15,6 +16,14 @@ public class PokeApiConfigurationProperties {
 
 	public void setBaseUri(URI baseUri) {
 		this.baseUri = baseUri;
+	}
+
+	public int getMaxBytesToBuffer() {
+		return maxBytesToBuffer;
+	}
+
+	public void setMaxBytesToBuffer(int maxBytesToBuffer) {
+		this.maxBytesToBuffer = maxBytesToBuffer;
 	}
 	
 }

--- a/src/main/java/skaro/pokeapi/PokeApiReactorBaseConfiguration.java
+++ b/src/main/java/skaro/pokeapi/PokeApiReactorBaseConfiguration.java
@@ -36,8 +36,6 @@ public class PokeApiReactorBaseConfiguration {
 	public static final String POKEAPI_JSON_DECODER_BEAN = "pokeapiDecoderBean";
 	public static final String POKEAPI_JSON_ENCODER_BEAN = "pokeapiEncoderBean";
 	
-	private static final int MAX_BYTES_TO_BUFFER = 550_000;
-	
 	@Bean
 	@Valid
 	@ConfigurationProperties(CONFIGURATION_PROPERTIES_PREFIX)
@@ -86,7 +84,8 @@ public class PokeApiReactorBaseConfiguration {
 				.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
 				.exchangeStrategies(strategies)
 				.filter(logRequest)
-				.codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(MAX_BYTES_TO_BUFFER))
+				.codecs(configurer -> configurer.defaultCodecs()
+						.maxInMemorySize(configurationProperties.getMaxBytesToBuffer()))
 				.build();
 	}
 	


### PR DESCRIPTION
Addresses issue #6 whereas the query for "/pokemon/mew" is bigger than the standard buffer-size