### PR TITLE
Named api resource list update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>skaro.pokeapi</groupId>
 	<artifactId>pokeapi-reactor</artifactId>
-	<version>1.0.6</version>
+	<version>1.0.7</version>
 	<name>pokeapi-reactor</name>
 	<description>Non-blocking, reactive API client for PokeAPI</description>
 	<properties>

--- a/src/main/java/skaro/pokeapi/resource/NamedApiResourceList.java
+++ b/src/main/java/skaro/pokeapi/resource/NamedApiResourceList.java
@@ -8,7 +8,7 @@ public class NamedApiResourceList<T extends PokeApiResource> implements PokeApiR
 
 	private Integer count;
 	private String next;
-	private Boolean previous;
+	private String previous;
 	private List<NamedApiResource<T>> results;
 	
 	public Integer getCount() {
@@ -23,10 +23,10 @@ public class NamedApiResourceList<T extends PokeApiResource> implements PokeApiR
 	public void setNext(String next) {
 		this.next = next;
 	}
-	public Boolean getPrevious() {
+	public String getPrevious() {
 		return previous;
 	}
-	public void setPrevious(Boolean previous) {
+	public void setPrevious(String previous) {
 		this.previous = previous;
 	}
 	public List<NamedApiResource<T>> getResults() {


### PR DESCRIPTION
This pull request addresses the bug found in this reported issue: https://github.com/SirSkaro/pokeapi-reactor/issues/8
I have also experienced this error, and found the cause and am providing a solution. 
Files Updated:
pom.xml --> Bumped up `version` to 1.0.7 for visibility on this issue
src/main/java/skaro/pokeapi/resource/NamedApiResourceList.java --> Changed type of `previous` from `Boolean` to `String`

Not Working:
<img width="1039" alt="Postman1 0 6ResponseNotWorking" src="https://github.com/SirSkaro/pokeapi-reactor/assets/19511224/a9044d1d-f02d-4d32-bd8f-e199d706f281">

Working:
<img width="1039" alt="Postman1 0 7ResponseWorking" src="https://github.com/SirSkaro/pokeapi-reactor/assets/19511224/fdf3be3d-77e2-4ab6-af9e-971ba251f929">

RestController: http://localhost:4201/pokemon/list?limit=10&offset=10  --> Retrieve next 10 Pokemon
<img width="1215" alt="RestControllerGet" src="https://github.com/SirSkaro/pokeapi-reactor/assets/19511224/ad990f2a-aefd-439d-b2f4-62bee6f5131a">
